### PR TITLE
Improve Xcode 8.3 and Swift compatibility

### DIFF
--- a/SMTWiFiStatus.podspec
+++ b/SMTWiFiStatus.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SMTWiFiStatus'
-  s.version          = '1.0.2'
+  s.version          = '1.0.3'
   s.summary          = 'SMTWiFiStatus is some functions to check for WiFi Status.'
 
 # This description is used to generate tags and improve search results.

--- a/SMTWiFiStatus/Classes/SMTWiFiStatus.h
+++ b/SMTWiFiStatus/Classes/SMTWiFiStatus.h
@@ -24,8 +24,8 @@ typedef NS_ENUM(NSUInteger, SMTWiFiPoweredState) {
 
 + (BOOL)                isWiFiEnabled;
 + (BOOL)                isWiFiConnected;
-+ (NSString *)          BSSID;
-+ (NSString *)          SSID;
++ (nullable NSString *) BSSID;
++ (nullable NSString *) SSID;
 
 + (BOOL)                hotspotEnabled;
 @end

--- a/SMTWiFiStatus/Classes/SMTWiFiStatus.m
+++ b/SMTWiFiStatus/Classes/SMTWiFiStatus.m
@@ -39,7 +39,7 @@
     return [[self class] wifiPoweredState] == SMTWiFiPoweredStateOn;
 }
 
-+ (NSDictionary *) wifiDetails {
++ (nullable NSDictionary *) wifiDetails {
 #ifdef TARGET_OS_SIMULATOR
     return NULL;
 #else
@@ -56,11 +56,11 @@
     return [SMTWiFiStatus wifiDetails] == nil ? NO : YES;
 }
 
-+ (NSString *) BSSID {
++ (nullable NSString *) BSSID {
     return [SMTWiFiStatus wifiDetails][@"BSSID"];
 }
 
-+ (NSString *) SSID {
++ (nullable NSString *) SSID {
 #ifdef TARGET_OS_SIMULATOR
     return NULL;
 #else
@@ -79,7 +79,7 @@
     return NO;
 }
 
-+ (NSDictionary *) getIPAddresses {
++ (nonnull NSDictionary *) getIPAddresses {
     NSMutableDictionary *addresses = [NSMutableDictionary dictionaryWithCapacity:8];
     
     // retrieve the current interfaces - returns 0 on success
@@ -116,7 +116,7 @@
         // Free memory
         freeifaddrs(interfaces);
     }
-    return [addresses count] ? addresses : nil;
+    return addresses;
 }
 
 @end

--- a/SMTWiFiStatus/Classes/SMTWiFiStatus.m
+++ b/SMTWiFiStatus/Classes/SMTWiFiStatus.m
@@ -40,7 +40,9 @@
 }
 
 + (NSDictionary *) wifiDetails {
-#ifndef TARGET_OS_SIMULATOR
+#ifdef TARGET_OS_SIMULATOR
+    return NULL;
+#else
     return
     (__bridge NSDictionary *)
 
@@ -59,7 +61,9 @@
 }
 
 + (NSString *) SSID {
-#ifndef TARGET_OS_SIMULATOR
+#ifdef TARGET_OS_SIMULATOR
+    return NULL;
+#else
     return [SMTWiFiStatus wifiDetails][@"SSID"];
 #endif
 }


### PR DESCRIPTION
- Fix compiler warnings that appear in Xcode 8.3 for projects depending on this
- Add nullability specifiers to improve importing this to Swift