### PR TITLE
Fix the simulator compiler directive

### DIFF
--- a/SMTWiFiStatus/Classes/SMTWiFiStatus.m
+++ b/SMTWiFiStatus/Classes/SMTWiFiStatus.m
@@ -40,7 +40,7 @@
 }
 
 + (nullable NSDictionary *) wifiDetails {
-#ifdef TARGET_OS_SIMULATOR
+#if TARGET_OS_SIMULATOR
     return NULL;
 #else
     return
@@ -61,7 +61,7 @@
 }
 
 + (nullable NSString *) SSID {
-#ifdef TARGET_OS_SIMULATOR
+#if TARGET_OS_SIMULATOR
     return NULL;
 #else
     return [SMTWiFiStatus wifiDetails][@"SSID"];


### PR DESCRIPTION
TARGET_OS_SIMULATOR is always defined (even when running on-device), it’s just defined as “false”.